### PR TITLE
Add color balance example

### DIFF
--- a/code/stimulus-control/bonsai/Shaders/ColorBalance.frag
+++ b/code/stimulus-control/bonsai/Shaders/ColorBalance.frag
@@ -11,5 +11,5 @@ out vec4 fragColor;
 void main()
 {
     vec4 color = texture(tex, texCoord * scale + shift);
-    fragColor = (color +  colorGain);
+    fragColor = color *  colorGain;
 }

--- a/code/stimulus-control/bonsai/Shaders/ColorBalance.frag
+++ b/code/stimulus-control/bonsai/Shaders/ColorBalance.frag
@@ -1,0 +1,15 @@
+#version 400
+
+uniform vec2 shift;
+uniform vec2 scale = vec2(1, 1);
+uniform vec4 colorGain = vec4(1, 1, 1, 1);
+uniform sampler2D tex;
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main()
+{
+    vec4 color = texture(tex, texCoord * scale + shift);
+    fragColor = (color +  colorGain);
+}

--- a/code/stimulus-control/src/Neuropixel/Extensions/ColorBalance.bonsai
+++ b/code/stimulus-control/src/Neuropixel/Extensions/ColorBalance.bonsai
@@ -1,0 +1,219 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
+                 xmlns:bv="clr-namespace:BonVision;assembly=BonVision"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:RenderTexture">
+          <gl:RenderState />
+          <gl:ClearColor>Black</gl:ClearColor>
+          <gl:ClearMask>DepthBufferBit ColorBufferBit</gl:ClearMask>
+          <gl:Width xsi:nil="true" />
+          <gl:Height xsi:nil="true" />
+          <gl:InternalFormat>Rgba</gl:InternalFormat>
+          <gl:WrapS>Repeat</gl:WrapS>
+          <gl:WrapT>Repeat</gl:WrapT>
+          <gl:MinFilter>Linear</gl:MinFilter>
+          <gl:MagFilter>Linear</gl:MagFilter>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:BindTexture">
+          <gl:TextureSlot>Texture0</gl:TextureSlot>
+          <gl:ShaderName>ColorBalance</gl:ShaderName>
+          <gl:TextureName />
+          <gl:TextureTarget>Texture2D</gl:TextureTarget>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:CreateOrthographic">
+          <gl:Width>1</gl:Width>
+          <gl:Height>1</gl:Height>
+          <gl:NearClip>-500</gl:NearClip>
+          <gl:FarClip>500</gl:FarClip>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ExtentX" />
+        <Property Name="ExtentY" />
+        <Property Name="LocationX" />
+        <Property Name="LocationY" />
+        <Property Name="Layer" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="Angle" Description="The angle of the image." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="bv:AngleProperty">
+          <bv:Value>0</bv:Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Angle" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>Transform</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="X" DisplayName="LocationX" />
+              <Property Name="Y" DisplayName="LocationY" />
+              <Property Name="Z" DisplayName="Layer" Description="The optional drawing overlay priority. Lower numbers appear below higher numbers." />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:Translate">
+                <gl:Order>Prepend</gl:Order>
+                <gl:X>0</gl:X>
+                <gl:Y>0</gl:Y>
+                <gl:Z>1</gl:Z>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Angle" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:RotateZ">
+                <gl:Order>Prepend</gl:Order>
+                <gl:Angle>0</gl:Angle>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="X" DisplayName="ExtentX" Description="The size of the image along the x-axis." />
+              <Property Name="Y" DisplayName="ExtentY" Description="The size of the image along the x-axis." />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:Scale">
+                <gl:Order>Prepend</gl:Order>
+                <gl:X>1</gl:X>
+                <gl:Y>1</gl:Y>
+                <gl:Z>1</gl:Z>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:UpdateUniform">
+                <gl:UniformName>transform</gl:UniformName>
+                <gl:ShaderName>ColorBalance</gl:ShaderName>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="2" Label="Source1" />
+            <Edge From="1" To="2" Label="Source2" />
+            <Edge From="2" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="4" To="6" Label="Source1" />
+            <Edge From="5" To="6" Label="Source2" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>ScaleShift</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="X" DisplayName="ScaleX" Category="Texture Mapping" />
+              <Property Name="Y" DisplayName="ScaleY" Category="Texture Mapping" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="bv:CreateTextureScale">
+                <bv:X>1</bv:X>
+                <bv:Y>1</bv:Y>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:UpdateUniform">
+                <gl:UniformName>scale</gl:UniformName>
+                <gl:ShaderName>ColorBalance</gl:ShaderName>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="X" DisplayName="ShiftX" Category="Texture Mapping" />
+              <Property Name="Y" DisplayName="ShiftY" Category="Texture Mapping" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="bv:CreateTextureShift">
+                <bv:X>0</bv:X>
+                <bv:Y>0</bv:Y>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="gl:UpdateUniform">
+                <gl:UniformName>shift</gl:UniformName>
+                <gl:ShaderName>ColorBalance</gl:ShaderName>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="2" Label="Source1" />
+            <Edge From="1" To="2" Label="Source2" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="5" Label="Source1" />
+            <Edge From="4" To="5" Label="Source2" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="X" DisplayName="R" />
+        <Property Name="Y" DisplayName="G" />
+        <Property Name="Z" DisplayName="B" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:CreateVector4">
+          <gl:X>0</gl:X>
+          <gl:Y>0</gl:Y>
+          <gl:Z>1</gl:Z>
+          <gl:W>1</gl:W>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:UpdateUniform">
+          <gl:UniformName>colorGain</gl:UniformName>
+          <gl:ShaderName>ColorBalance</gl:ShaderName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="gl:DrawMesh">
+          <gl:ShaderName>ColorBalance</gl:ShaderName>
+          <gl:MeshName>Quad</gl:MeshName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="8" Label="Source1" />
+      <Edge From="4" To="8" Label="Source2" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source3" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="11" Label="Source1" />
+      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/code/stimulus-control/src/Neuropixel/Standard_oddball_neuropixel.bonsai
+++ b/code/stimulus-control/src/Neuropixel/Standard_oddball_neuropixel.bonsai
@@ -65,6 +65,21 @@
               <gl:VertexShader>BonVision:Shaders.Gratings.vert</gl:VertexShader>
               <gl:FragmentShader>..\..\bonsai\Shaders\GeneralColoredGratings.frag</gl:FragmentShader>
             </gl:ShaderConfiguration>
+            <gl:ShaderConfiguration xsi:type="gl:Material">
+              <gl:Name>ColorBalance</gl:Name>
+              <gl:RenderState />
+              <gl:ShaderUniforms />
+              <gl:BufferBindings>
+                <gl:BufferBinding xsi:type="gl:TextureBinding">
+                  <gl:Name>tex</gl:Name>
+                  <gl:TextureSlot>Texture0</gl:TextureSlot>
+                  <gl:TextureTarget>Texture2D</gl:TextureTarget>
+                </gl:BufferBinding>
+              </gl:BufferBindings>
+              <gl:FramebufferAttachments />
+              <gl:VertexShader>BonVision:Shaders.Quad.vert</gl:VertexShader>
+              <gl:FragmentShader>..\..\bonsai\Shaders\ColorBalance.frag</gl:FragmentShader>
+            </gl:ShaderConfiguration>
           </gl:Shaders>
         </Combinator>
       </Expression>
@@ -795,31 +810,23 @@ groupMasks:
         </Translation>
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="gl:RenderTexture">
-          <gl:RenderState />
-          <gl:ClearColor>Black</gl:ClearColor>
-          <gl:ClearMask>DepthBufferBit ColorBufferBit</gl:ClearMask>
-          <gl:Width xsi:nil="true" />
-          <gl:Height xsi:nil="true" />
-          <gl:InternalFormat>Rgba</gl:InternalFormat>
-          <gl:WrapS>Repeat</gl:WrapS>
-          <gl:WrapT>Repeat</gl:WrapT>
-          <gl:MinFilter>Linear</gl:MinFilter>
-          <gl:MagFilter>Linear</gl:MagFilter>
+        <Combinator xsi:type="gl:UpdateViewportState">
+          <gl:X>0</gl:X>
+          <gl:Y>0</gl:Y>
+          <gl:Width>1</gl:Width>
+          <gl:Height>1</gl:Height>
         </Combinator>
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="gl:BindTexture">
-          <gl:TextureSlot>Texture0</gl:TextureSlot>
-          <gl:ShaderName>ColoredGratings</gl:ShaderName>
-          <gl:TextureTarget>Texture2D</gl:TextureTarget>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="gl:DrawMesh">
-          <gl:ShaderName>ColoredGratings</gl:ShaderName>
-          <gl:MeshName>Plane</gl:MeshName>
-        </Combinator>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ColorBalance.bonsai">
+        <ExtentX>1</ExtentX>
+        <ExtentY>1</ExtentY>
+        <LocationX>0</LocationX>
+        <LocationY>0</LocationY>
+        <Layer>1</Layer>
+        <Angle>0</Angle>
+        <R>0</R>
+        <G>0</G>
+        <B>1</B>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Value" DisplayName="BlueStim (1=Yes, 0=No)" />
@@ -1267,60 +1274,59 @@ double.Parse(it[2]) as Y)</scr:Expression>
       <Edge From="47" To="48" Label="Source1" />
       <Edge From="48" To="49" Label="Source1" />
       <Edge From="49" To="50" Label="Source1" />
-      <Edge From="50" To="51" Label="Source1" />
+      <Edge From="51" To="52" Label="Source1" />
       <Edge From="52" To="53" Label="Source1" />
-      <Edge From="53" To="54" Label="Source1" />
+      <Edge From="54" To="55" Label="Source1" />
       <Edge From="55" To="56" Label="Source1" />
-      <Edge From="56" To="57" Label="Source1" />
-      <Edge From="57" To="59" Label="Source1" />
-      <Edge From="58" To="59" Label="Source2" />
-      <Edge From="58" To="65" Label="Source2" />
-      <Edge From="58" To="73" Label="Source2" />
-      <Edge From="59" To="60" Label="Source1" />
-      <Edge From="60" To="82" Label="Source1" />
-      <Edge From="61" To="63" Label="Source1" />
-      <Edge From="62" To="63" Label="Source2" />
-      <Edge From="63" To="66" Label="Source1" />
-      <Edge From="64" To="65" Label="Source1" />
-      <Edge From="65" To="66" Label="Source2" />
+      <Edge From="56" To="58" Label="Source1" />
+      <Edge From="57" To="58" Label="Source2" />
+      <Edge From="57" To="64" Label="Source2" />
+      <Edge From="57" To="72" Label="Source2" />
+      <Edge From="58" To="59" Label="Source1" />
+      <Edge From="59" To="81" Label="Source1" />
+      <Edge From="60" To="62" Label="Source1" />
+      <Edge From="61" To="62" Label="Source2" />
+      <Edge From="62" To="65" Label="Source1" />
+      <Edge From="63" To="64" Label="Source1" />
+      <Edge From="64" To="65" Label="Source2" />
+      <Edge From="65" To="66" Label="Source1" />
       <Edge From="66" To="67" Label="Source1" />
       <Edge From="67" To="68" Label="Source1" />
-      <Edge From="68" To="69" Label="Source1" />
-      <Edge From="69" To="82" Label="Source2" />
+      <Edge From="68" To="81" Label="Source2" />
+      <Edge From="69" To="70" Label="Source1" />
       <Edge From="70" To="71" Label="Source1" />
       <Edge From="71" To="72" Label="Source1" />
       <Edge From="72" To="73" Label="Source1" />
-      <Edge From="73" To="74" Label="Source1" />
-      <Edge From="74" To="82" Label="Source3" />
+      <Edge From="73" To="81" Label="Source3" />
+      <Edge From="74" To="75" Label="Source1" />
       <Edge From="75" To="76" Label="Source1" />
       <Edge From="76" To="77" Label="Source1" />
-      <Edge From="77" To="78" Label="Source1" />
-      <Edge From="78" To="80" Label="Source1" />
-      <Edge From="79" To="80" Label="Source2" />
-      <Edge From="80" To="81" Label="Source1" />
-      <Edge From="81" To="82" Label="Source4" />
+      <Edge From="77" To="79" Label="Source1" />
+      <Edge From="78" To="79" Label="Source2" />
+      <Edge From="79" To="80" Label="Source1" />
+      <Edge From="80" To="81" Label="Source4" />
+      <Edge From="81" To="82" Label="Source1" />
+      <Edge From="81" To="84" Label="Source1" />
       <Edge From="82" To="83" Label="Source1" />
-      <Edge From="82" To="85" Label="Source1" />
-      <Edge From="83" To="84" Label="Source1" />
-      <Edge From="84" To="87" Label="Source1" />
-      <Edge From="85" To="86" Label="Source1" />
-      <Edge From="86" To="87" Label="Source2" />
+      <Edge From="83" To="86" Label="Source1" />
+      <Edge From="84" To="85" Label="Source1" />
+      <Edge From="85" To="86" Label="Source2" />
+      <Edge From="86" To="87" Label="Source1" />
       <Edge From="87" To="88" Label="Source1" />
       <Edge From="88" To="89" Label="Source1" />
-      <Edge From="89" To="90" Label="Source1" />
-      <Edge From="91" To="95" Label="Source1" />
+      <Edge From="90" To="94" Label="Source1" />
+      <Edge From="91" To="92" Label="Source1" />
       <Edge From="92" To="93" Label="Source1" />
-      <Edge From="93" To="94" Label="Source1" />
-      <Edge From="94" To="95" Label="Source2" />
-      <Edge From="95" To="96" Label="Source1" />
-      <Edge From="96" To="99" Label="Source1" />
-      <Edge From="97" To="98" Label="Source1" />
-      <Edge From="98" To="99" Label="Source2" />
-      <Edge From="100" To="105" Label="Source1" />
+      <Edge From="93" To="94" Label="Source2" />
+      <Edge From="94" To="95" Label="Source1" />
+      <Edge From="95" To="98" Label="Source1" />
+      <Edge From="96" To="97" Label="Source1" />
+      <Edge From="97" To="98" Label="Source2" />
+      <Edge From="99" To="104" Label="Source1" />
+      <Edge From="100" To="101" Label="Source1" />
       <Edge From="101" To="102" Label="Source1" />
-      <Edge From="102" To="103" Label="Source1" />
-      <Edge From="103" To="105" Label="Source2" />
-      <Edge From="104" To="105" Label="Source3" />
+      <Edge From="102" To="104" Label="Source2" />
+      <Edge From="103" To="104" Label="Source3" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR adds an example on how to make a final pass to color balance all pixels in a shader's window.

The functionality is exposed via `ColorBalance` operator and should be added as one of the final steps of the rendering pipeline:

![image](https://github.com/user-attachments/assets/5b475c92-d636-44de-8e4e-440485edd994)

As a side note, `UpdateViewportState` is added to ensure that the shader can operate on normalized coordinates.

The color balance can be set (manually or automatically) via the RGB properties in the operator and will change the output accordingly.